### PR TITLE
[discussion] modify redux/connect per discussion on Facebook 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2775,7 +2775,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2793,11 +2794,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2810,15 +2813,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2921,7 +2927,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2931,6 +2938,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2943,17 +2951,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2970,6 +2981,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3042,7 +3054,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3052,6 +3065,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3127,7 +3141,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3157,6 +3172,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3174,6 +3190,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3212,11 +3229,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6762,7 +6781,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -6780,11 +6800,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -6797,15 +6819,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -6908,7 +6933,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -6918,6 +6944,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -6930,17 +6957,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -6957,6 +6987,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -7029,7 +7060,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -7039,6 +7071,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -7114,7 +7147,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -7144,6 +7178,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -7161,6 +7196,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -7199,11 +7235,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         }

--- a/src/App.js
+++ b/src/App.js
@@ -1,37 +1,23 @@
-import React from 'react'
-import { Provider, connect } from 'react-redux'
+import React from 'react';
+import { Provider } from 'react-redux';
 
-import './App.css'
-import store from './redux/store'
+import './App.css';
+import store from './redux/store';
 
-import Sibling from './components/Sibling'
-import Counter from './components/Counter'
+import Sibling from './components/Sibling';
+import Counter from './components/Counter';
+import Arrow from './components/Arrow';
 
-const App = ({ count, firingComponent }) => {
-  const arrowStyle = { visibility: count % 2 === 0 ? 'hidden' : 'visible' }
-  const arrowDirection = `fas fa-arrow-alt-circle-${firingComponent === 'sibling' ? 'right' : 'left'}`
+const App = () => {
+	return (
+		<Provider store={store}>
+			<div className="App">
+				<Sibling />
+				<Arrow isBig />
+				<Counter />
+			</div>
+		</Provider>
+	);
+};
 
-  return (
-    <div className="App">
-      <Sibling />
-      <div className="icon icon-big" style={arrowStyle}>
-        <i className={arrowDirection} />
-      </div>
-      <Counter />
-    </div>
-  )
-}
-
-const mapStateToProps = state => ({ ...state })
-
-const ConnectWrappedAppComponent = connect(mapStateToProps)(App)
-
-const ProviderWrappedConnectWrappedAppComponent = () => {
-  return (
-    <Provider store={store}>
-      <ConnectWrappedAppComponent />
-    </Provider>
-  )
-}
-
-export default ProviderWrappedConnectWrappedAppComponent
+export default App;

--- a/src/components/Arrow.js
+++ b/src/components/Arrow.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+const Arrow = ({ count, firingComponent, arrowStyle, arrowDirection, isBig }) => {
+	const _arrowStyle = arrowStyle || { visibility: count % 2 === 0 ? 'hidden' : 'visible' };
+	const _arrowDirection =
+		arrowDirection || `fas fa-arrow-alt-circle-${firingComponent === 'sibling' ? 'right' : 'left'}`;
+
+	return (
+		<div className={`icon ${isBig && 'icon-big'}`} style={_arrowStyle}>
+			<i className={_arrowDirection} />
+		</div>
+	);
+};
+
+Arrow.defaultProps = {
+	isBig: false
+};
+
+const mapStateToProps = state => ({ ...state });
+
+export default connect(mapStateToProps)(Arrow);

--- a/src/components/Child.js
+++ b/src/components/Child.js
@@ -1,23 +1,23 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
-import GrandChild from './GrandChild'
+import GrandChild from './GrandChild';
 
 const Child = ({ count, firingComponent }) => {
-  const arrowStyle = { visibility: count % 2 === 0 || firingComponent === 'sibling' ? 'hidden' : 'visible' }
-  const arrowDirection = `fas fa-arrow-alt-circle-${firingComponent === 'greatGrandChild' ? 'up' : 'down'}`
+	const arrowStyle = { visibility: count % 2 === 0 || firingComponent === 'sibling' ? 'hidden' : 'visible' };
+	const arrowDirection = `fas fa-arrow-alt-circle-${firingComponent === 'greatGrandChild' ? 'up' : 'down'}`;
 
-  return (
-    <div className="child">
-      <h3>Child</h3>
-      <div className="icon" style={arrowStyle}>
-        <i className={arrowDirection} />
-      </div>
-      <GrandChild />
-    </div>
-  )
-}
+	return (
+		<div className="child">
+			<h3>Child</h3>
+			<div className="icon" style={arrowStyle}>
+				<i className={arrowDirection} />
+			</div>
+			<GrandChild />
+		</div>
+	);
+};
 
-const mapStateToProps = state => ({ ...state })
+const mapStateToProps = state => ({ ...state });
 
-export default connect(mapStateToProps)(Child)
+export default connect(mapStateToProps)(Child);

--- a/src/components/Counter.js
+++ b/src/components/Counter.js
@@ -1,46 +1,47 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
-import Child from './Child'
+import Child from './Child';
 
-import { useInterval } from '../utils'
+import { useInterval } from '../utils';
+import Arrow from './Arrow';
 
-const Counter = ({ count, dispatch, firingComponent }) => {
-  useInterval(() => {
-    dispatch({ type: 'COUNTER_FIRING' })
-  }, 1000)
+const Counter = ({ count, dispatch, firingComponent, increaseCount }) => {
+	useInterval(increaseCount, 1000);
 
-  let conditionalBg
-  let arrowDirection = 'fas fa-arrow-alt-circle-'
+	let conditionalBg;
+	let arrowDirection = 'fas fa-arrow-alt-circle-';
 
-  if (firingComponent === 'counter') {
-    conditionalBg = { backgroundColor: '#508AA8' }
-    arrowDirection += 'down'
-  } else {
-    arrowDirection += 'up'
-  }
+	if (firingComponent === 'counter') {
+		conditionalBg = { backgroundColor: '#508AA8' };
+		arrowDirection += 'down';
+	} else {
+		arrowDirection += 'up';
+	}
 
-  const arrowStyle = { opacity: count % 2 === 0 || firingComponent === 'sibling' ? 0 : 1 }
+	const arrowStyle = { opacity: count % 2 === 0 || firingComponent === 'sibling' ? 0 : 1 };
 
-  return (
-    <div className="counter" style={conditionalBg}>
-      <h3>Counter</h3>
-      <span className="number">{count}</span>
-      <div style={{ marginBottom: 10 }}>
-        <button onClick={() => dispatch({ type: 'COUNTER_FIRING' })}>
-          Increment
-        </button>
-      </div>
-      <div className="counterChildren">
-        <div className="icon">
-          <i className={arrowDirection} style={arrowStyle} />
-        </div>
-        <Child />
-      </div>
-    </div>
-  )
-}
+	return (
+		<div className="counter" style={conditionalBg}>
+			<h3>Counter</h3>
+			<span className="number">{count}</span>
+			<div style={{ marginBottom: 10 }}>
+				<button onClick={() => dispatch({ type: 'COUNTER_FIRING' })}>Increment</button>
+			</div>
+			<div className="counterChildren">
+				<Arrow arrowStyle={arrowStyle} arrowDirection={arrowDirection} />
+				<Child />
+			</div>
+		</div>
+	);
+};
 
-const mapStateToProps = state => ({ ...state })
+const mapStateToProps = state => ({ ...state });
+const mapDispatchToProps = dispatch => ({
+	increaseCount: () => dispatch({ type: 'COUNTER_FIRING', payload: { firingComponent: 'counter' } })
+});
 
-export default connect(mapStateToProps)(Counter)
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(Counter);

--- a/src/components/GrandChild.js
+++ b/src/components/GrandChild.js
@@ -1,23 +1,22 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
-import GreatGrandChild from './GreatGrandChild'
+import GreatGrandChild from './GreatGrandChild';
+import Arrow from './Arrow';
 
 const GrandChild = ({ count, firingComponent }) => {
-  const arrowDirection = `fas fa-arrow-alt-circle-${firingComponent === 'greatGrandChild' ? 'up' : 'down'}`
-  const arrowStyle = { visibility: count % 2 === 0 || firingComponent === 'sibling' ? 'hidden' : 'visible' }
+	const arrowDirection = `fas fa-arrow-alt-circle-${firingComponent === 'greatGrandChild' ? 'up' : 'down'}`;
+	const arrowStyle = { visibility: count % 2 === 0 || firingComponent === 'sibling' ? 'hidden' : 'visible' };
 
-  return (
-    <div className="grandChild">
-      <h3>Grand Child</h3>
-      <div className="icon" style={arrowStyle}>
-        <i className={arrowDirection} />
-      </div>
-      <GreatGrandChild />
-    </div>
-  )
-}
+	return (
+		<div className="grandChild">
+			<h3>Grand Child</h3>
+			<Arrow arrowStyle={arrowStyle} arrowDirection={arrowDirection} />
+			<GreatGrandChild />
+		</div>
+	);
+};
 
-const mapStateToProps = state => ({ ...state })
+const mapStateToProps = state => ({ ...state });
 
-export default connect(mapStateToProps)(GrandChild)
+export default connect(mapStateToProps)(GrandChild);

--- a/src/components/GreatGrandChild.js
+++ b/src/components/GreatGrandChild.js
@@ -1,23 +1,27 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
-const GreatGrandChild = ({ count, dispatch, firingComponent }) => {
-  let bgStyle
-  if (firingComponent === 'greatGrandChild') {
-    bgStyle = { backgroundColor: '#508AA8' }
-  }
+const GreatGrandChild = ({ count, firingComponent, increaseCount }) => {
+	let bgStyle;
+	if (firingComponent === 'greatGrandChild') {
+		bgStyle = { backgroundColor: '#508AA8' };
+	}
 
-  return (
-    <div className="greatGrandChild" style={bgStyle}>
-      <h3>Great Grand Child</h3>
-      <span className="number">{count}</span>
-      <button onClick={() => dispatch({ type: 'GREAT_GRAND_CHILD_FIRING' })}>
-        Increment
-      </button>
-    </div>
-  )
-}
+	return (
+		<div className="greatGrandChild" style={bgStyle}>
+			<h3>Great Grand Child</h3>
+			<span className="number">{count}</span>
+			<button onClick={increaseCount}>Increment</button>
+		</div>
+	);
+};
 
-const mapStateToProps = state => ({ ...state })
+const mapStateToProps = state => ({ ...state });
+const mapDispatchToProps = dispatch => ({
+	increaseCount: () => dispatch({ type: 'COUNTER_FIRING', payload: { firingComponent: 'greatGrandChild' } })
+});
 
-export default connect(mapStateToProps)(GreatGrandChild)
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(GreatGrandChild);

--- a/src/components/Sibling.js
+++ b/src/components/Sibling.js
@@ -1,24 +1,28 @@
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
-const Sibling = ({ count, dispatch, firingComponent }) => {
-  const origin = firingComponent === 'sibling'
-  let siblingStyle
-  if (origin) {
-    siblingStyle = { backgroundColor: '#508AA8' }
-  }
+const Sibling = ({ count, increaseCount, firingComponent }) => {
+	const origin = firingComponent === 'sibling';
+	let siblingStyle;
+	if (origin) {
+		siblingStyle = { backgroundColor: '#508AA8' };
+	}
 
-  return (
-    <div className="sibling" style={siblingStyle}>
-      <h3>Sibling</h3>
-      <span className="number">{count}</span>
-      <button onClick={() => dispatch({ type: 'SIBLING_FIRING' })}>
-        Increment
-      </button>
-    </div>
-  )
-}
+	return (
+		<div className="sibling" style={siblingStyle}>
+			<h3>Sibling</h3>
+			<span className="number">{count}</span>
+			<button onClick={increaseCount}>Increment</button>
+		</div>
+	);
+};
 
-const mapStateToProps = state => ({ ...state })
+const mapStateToProps = state => ({ ...state });
+const mapDispatchToProps = dispatch => ({
+	increaseCount: () => dispatch({ type: 'COUNTER_FIRING', payload: { firingComponent: 'sibling' } })
+});
 
-export default connect(mapStateToProps)(Sibling)
+export default connect(
+	mapStateToProps,
+	mapDispatchToProps
+)(Sibling);

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,35 +1,22 @@
-import { createStore } from 'redux'
+import { createStore } from 'redux';
 
 const initialState = {
-  count: 0,
-  firingComponent: null
-}
+	count: 0,
+	firingComponent: null
+};
 
 const counter = (state = initialState, action) => {
-  switch(action.type) {
-    case 'COUNTER_FIRING':
-      return {
-        count: state.count + 1,
-        firingComponent: 'counter'
-      }
-    case 'SIBLING_FIRING':
-      return {
-        count: state.count + 1,
-        firingComponent: 'sibling'
-      }
-    case 'GREAT_GRAND_CHILD_FIRING':
-      return {  
-        count: state.count + 1, 
-        firingComponent: 'greatGrandChild' 
-      }
-    default:
-      return state;
-  }
-}
+	switch (action.type) {
+		case 'COUNTER_FIRING':
+			return {
+				count: state.count + 1,
+				firingComponent: action.payload.firingComponent
+			};
+		default:
+			return state;
+	}
+};
 
-const store = createStore(
-  counter,
-  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
-);
+const store = createStore(counter, window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__());
 
-export default store
+export default store;


### PR DESCRIPTION
I moved `Arrow` out to its own component. However, I didn't really look closely into how `Arrow` is worked out so it's kind of rough moving it. 

Moving `Arrow` into its own component frees up `AppComponent` by a lot by not having to connect `App` to `redux`. 

Consolidate reducer to 1 Action `COUNTER_FIRING` instead of 3 Actions.

Utilize `mapDispatchToProps` to allow the components to be unaware of `dispatch`. This also results in a cleaner code base where you only have to pass the reference to the method `increaseCount` like `onClick={increaseCount}` instead of having to call it `onClick={() => increaseCount()}` 